### PR TITLE
fix: use SPA build for Docker frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN yarn install --immutable
 
 # Then copy source and build
 COPY frontend/ .
-RUN yarn build
+RUN yarn build:spa
 
 # ---------- BACKEND ----------
 FROM python:3.11-slim AS runtime
@@ -35,7 +35,7 @@ COPY backend/ .
 RUN uv sync --frozen --no-dev
 
 # Copy built frontend into the static directory
-COPY --from=frontend-builder /app/frontend/dist ./static
+COPY --from=frontend-builder /app/frontend/dist-spa ./static
 
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 


### PR DESCRIPTION
## Summary
- Changes `yarn build` → `yarn build:spa` in the Dockerfile
- Changes COPY path from `dist` → `dist-spa`

## Problem
`yarn build` uses `vite.config.ts` which is a **library** build — it produces JS/CSS bundles but **no `index.html`**. The static file serving added in #71 looks for `index.html` to detect the static dir, finds nothing, and all requests 404.

`yarn build:spa` uses `vite.config.spa.ts` which produces a proper SPA with `index.html` + `assets/` in `dist-spa/`.

## Test plan
- [ ] Merge and verify HF Spaces serves the frontend at `/`