### PR TITLE
fix: set explicit version for PyPI build to avoid dirty suffix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
           enable-cache: true
       - name: Build package (with bundled frontend)
         working-directory: backend
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ needs.validate.outputs.version }}
         run: uv build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The frontend SPA build and hatch build hook make the git tree dirty, causing setuptools-scm to append .dev0+g...d... to the version. PyPI rejects local version identifiers. Use SETUPTOOLS_SCM_PRETEND_VERSION from the tag to produce a clean version like 0.6.0.